### PR TITLE
Fix theme attributes causing resource linking errors

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,8 +2,9 @@
     <style name="Base.Theme.Lab3" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorOnPrimary">@color/colorOnPrimary</item>
-        <item name="statusBarColor">@color/colorPrimary</item>
-        <item name="navigationBarColor">@color/colorPrimary</item>
+        <!-- Prefix built-in bar color attributes with the android namespace -->
+        <item name="android:statusBarColor">@color/colorPrimary</item>
+        <item name="android:navigationBarColor">@color/colorPrimary</item>
     </style>
 
     <style name="Theme.Lab3" parent="Base.Theme.Lab3" />


### PR DESCRIPTION
## Summary
- use `android:` namespace for status and navigation bar colors

## Testing
- `./gradlew assembleDebug --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a0a19cfc8332a1538726ffd3a3a8